### PR TITLE
Add ParameterDict.setdefault, including unit tests

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1834,6 +1834,14 @@ class TestNN(NNTestCase):
         parameters.pop('p4')
         check()
 
+        parameters['p11'] = Parameter(torch.randn(10, 10))
+        p_setdefault = parameter_dict.setdefault('p11', parameters['p11'])
+        self.assertIs(p_setdefault, parameters['p11'])
+
+        p = Parameter(torch.randn(10, 10))
+        self.assertFalse(parameter_dict.setdefault('p11', p) is p)
+        check()
+
         parameter_dict.clear()
         self.assertEqual(len(parameter_dict), 0)
         parameters.clear()

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -606,6 +606,20 @@ class ParameterDict(Module):
     def __contains__(self, key: str) -> bool:
         return key in self._parameters
 
+    def setdefault(self, key: str, default: Optional['Parameter'] = None) -> 'Parameter':
+        """If key is in the ParameterDict, return its parameter.
+        If not, insert `key` with a parameter `default` and return `default`.
+        `default` defaults to `None`.
+
+        Args:
+            key (string): key to set default for
+            default (:class:`~torch.nn.Parameter`): the parameter set to the key
+        """
+        if key in self._parameters:
+            return self._parameters[key]
+        self.register_parameter(key, default)
+        return self._parameters[key]
+
     def clear(self) -> None:
         """Remove all items from the ParameterDict.
         """

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -617,7 +617,7 @@ class ParameterDict(Module):
         """
         if key in self._parameters:
             return self._parameters[key]
-        self.register_parameter(key, default)
+        self[key] = default
         return self._parameters[key]
 
     def clear(self) -> None:


### PR DESCRIPTION
Partially resolves https://github.com/pytorch/pytorch/issues/68476#issuecomment-974757852

- Add `.setdefault()` to `ParameterDict`
- Add unit tests for `ParameterDict.setdefault()`