### PR TITLE
Add ParameterDict.get()

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -1839,6 +1839,15 @@ class TestNN(NNTestCase):
         parameters.clear()
         check()
 
+        parameters['p17'] = Parameter(torch.randn(10, 10))
+        parameter_dict['p17'] = parameters['p17']
+        self.assertIs(parameters['p17'], parameter_dict.get('p17'))
+        temp_param = Parameter(torch.randn(10, 10))
+        self.assertIs(parameters['p17'], parameter_dict.get('p17', temp_param))
+        self.assertIs(None, parameter_dict.get('p18'))
+        self.assertIs(temp_param, parameter_dict.get('p18', temp_param))
+        check()
+
     def test_add_module(self):
         methods_to_test = ['add_module', 'register_module']
         for fn in methods_to_test:

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -621,7 +621,7 @@ class ParameterDict(Module):
         del self[key]
         return v
 
-    def get(self, key: str, default: Optional['Parameter'] = None) -> 'Parameter':
+    def get(self, key: str, default: 'Parameter' = None) -> 'Parameter':
         r"""Return the parameter associated with key if present.
             Otherwise return default if provided, None if not.
 

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -621,7 +621,7 @@ class ParameterDict(Module):
         del self[key]
         return v
 
-    def get(self, key: str, default: Parameter = None) -> 'Parameter':
+    def get(self, key: str, default: Optional[Parameter] = None) -> 'Parameter':
         r"""Return the parameter associated with key if present.
             Otherwise return default if provided, None if not.
 

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -621,7 +621,7 @@ class ParameterDict(Module):
         del self[key]
         return v
 
-    def get(self, key: str, default: 'Parameter' = None) -> 'Parameter':
+    def get(self, key: str, default: Optional['Parameter'] = None) -> 'Parameter | None':
         r"""Return the parameter associated with key if present.
             Otherwise return default if provided, None if not.
 

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -621,6 +621,18 @@ class ParameterDict(Module):
         del self[key]
         return v
 
+    def get(self, key: str, default: Parameter = None) -> 'Parameter':
+        r"""Return the parameter associated with key if present.
+            Otherwise return default if provided, None if not.
+
+        Args:
+            key (string): key to get from the ParameterDict
+            default (Parameter, optional): value to return if key not present
+        """
+        if key in self._parameters:
+            return self[key]
+        return default
+
     def keys(self) -> Iterable[str]:
         r"""Return an iterable of the ParameterDict keys.
         """

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -621,7 +621,7 @@ class ParameterDict(Module):
         del self[key]
         return v
 
-    def get(self, key: str, default: Optional[Parameter] = None) -> 'Parameter':
+    def get(self, key: str, default: Optional['Parameter'] = None) -> 'Parameter':
         r"""Return the parameter associated with key if present.
             Otherwise return default if provided, None if not.
 
@@ -629,9 +629,7 @@ class ParameterDict(Module):
             key (string): key to get from the ParameterDict
             default (Parameter, optional): value to return if key not present
         """
-        if key in self._parameters:
-            return self[key]
-        return default
+        return self._parameters.get(key, default)
 
     def keys(self) -> Iterable[str]:
         r"""Return an iterable of the ParameterDict keys.


### PR DESCRIPTION
Partially resolves pytorch#68476

- Add `.get()` to `ParameterDict`
- Add unit tests for `ParameterDict.get()`