### PR TITLE
Suppress mypy warning for incompatible types in assignment in ParameterDict.setdefault

### DIFF
--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -617,7 +617,7 @@ class ParameterDict(Module):
         """
         if key in self._parameters:
             return self._parameters[key]
-        self[key] = default
+        self[key] = default # type: ignore
         return self._parameters[key]
 
     def clear(self) -> None:

--- a/torch/nn/modules/container.py
+++ b/torch/nn/modules/container.py
@@ -617,7 +617,7 @@ class ParameterDict(Module):
         """
         if key in self._parameters:
             return self._parameters[key]
-        self[key] = default # type: ignore
+        self[key] = default  # type: ignore[assignment]
         return self._parameters[key]
 
     def clear(self) -> None:


### PR DESCRIPTION
Fixes https://github.com/thisisalbertliang/pytorch/pull/1#pullrequestreview-822901770

